### PR TITLE
Use lowercase a to declare array (closes #4)

### DIFF
--- a/hoarder.sh
+++ b/hoarder.sh
@@ -243,9 +243,9 @@ END
 }
 
 # keep track of the .torrent files to be downloaded
-declare -A TORRENT_QUEUE
+declare -a TORRENT_QUEUE
 # keep track of the rsyncs to download torrent data
-declare -A RUNNING_RSYNCS
+declare -a RUNNING_RSYNCS
 # run indefinitely
 while true; do
 	# check to make sure the path of the local .torrent files exists
@@ -253,7 +253,7 @@ while true; do
 		echo "${TORRENT_FILE_PATH} Does not exist"
 		exit 1
 	fi
-	
+
 	OIFS="$IFS"
 	IFS=$'\n'
 	# enumerate the .torrent file directory


### PR DESCRIPTION
Figured why not? Seems like bash documentation all references a lowercase `-a` anyway. Not certain what you have `/bin/sh` linked to, but I can't find any mention of using `declare -a` with bourne shell, so I assume it's not that?