### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ resume_downloads: true
 
 rtorrent:
   # The address to the rtorrent XMLRPC endpoint
-  addr: mycoolrtorrentserver.com/XMLRPC
+  addr: https://mycoolrtorrentserver.com/XMLRPC
 
   # true to ignore the certificate authenticity; false to honor it
   insecure_cert: false


### PR DESCRIPTION
Include protocol scheme in the `rutorrent.addr` attribute. Omission of this gives me a frustratingly unhelpful error `Failed to update torrent list from rTorrent: 'Post mycoolrtorrentserver.com/XMLRPC: unsupported protocol scheme ""'`