### PR TITLE
Implement download progress checking via RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ download_jobs: 2
 # Whether or not to attempt to resume a previously interrupted download
 resume_downloads: true
 
+# Path to the unix socket file that hoarder uses for RPC
+rpc_socket_path: /tmp/hoarder.sock
+
 rtorrent:
   # The address to the rtorrent XMLRPC endpoint
   addr: https://mycoolrtorrentserver.com/XMLRPC

--- a/cmd/hoarder/main.go
+++ b/cmd/hoarder/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tblyler/hoarder/queue"
 	"io/ioutil"
 	"log"
+	"net/rpc"
 	"os"
 	"os/signal"
 	"strconv"
@@ -19,6 +20,7 @@ var buildDate = "Unknown"
 func main() {
 	version := flag.Bool("version", false, "display version info")
 	configPath := flag.String("config", "", "path to the config file")
+	getStatus := flag.Bool("getStatus", false, "get the status of the current downloads")
 	flag.Parse()
 
 	if *version {
@@ -54,6 +56,29 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *getStatus {
+		rpc, err := rpc.Dial("unix", config.RPCSocketPath)
+		if err != nil {
+			logger.Printf("Unable to open RPC socket file '%s': '%s'", config.RPCSocketPath, err)
+			os.Exit(1)
+		}
+		defer rpc.Close()
+
+		reply := ""
+		err = rpc.Call("Status.Downloads", &queue.RPCArgs{}, &reply)
+		if err != nil {
+			logger.Printf("RPC call for download status failed: '%s'", err)
+			os.Exit(1)
+		}
+
+		if len(reply) > 0 {
+			fmt.Println(reply)
+		} else {
+			fmt.Println("No Downloads")
+		}
+		os.Exit(0)
+	}
+
 	q, err := queue.NewQueue(config, logger)
 	if err != nil {
 		logger.Printf("Failed to start hoarder: '%s'", err)
@@ -74,4 +99,9 @@ func main() {
 	logger.Println("Got signal ", sig, " quitting")
 	stop <- true
 	<-done
+
+	errs := q.Close()
+	for _, err := range errs {
+		logger.Println(err)
+	}
 }

--- a/cmd/hoarder/main.go
+++ b/cmd/hoarder/main.go
@@ -62,7 +62,6 @@ func main() {
 			logger.Printf("Unable to open RPC socket file '%s': '%s'", config.RPCSocketPath, err)
 			os.Exit(1)
 		}
-		defer rpc.Close()
 
 		reply := ""
 		err = rpc.Call("Status.Downloads", &queue.RPCArgs{}, &reply)
@@ -76,6 +75,8 @@ func main() {
 		} else {
 			fmt.Println("No Downloads")
 		}
+
+		rpc.Close()
 		os.Exit(0)
 	}
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -262,9 +262,9 @@ func dirSize(path string) (int64, error) {
 }
 
 /* Output looks like
-Errored.Download.mkv			      |                              |  (error: could not stat file)
 Totally.Legit.Download.x264-KILLERS   |===============>              |  (50%)
-ubuntu.13.37.iso  					  |===>		              		 |  ( 7%)
+ubuntu.13.37.iso                      |===>                          |  ( 7%)
+Errored.Download.mkv                  |                              |  (error: could not stat file)
 */
 func (q *Queue) getDownloadStatus(downloadsRunning map[string]downloadInfo) string {
 	// We use maps so that we can traverse in name order

--- a/queue/rpc.go
+++ b/queue/rpc.go
@@ -1,0 +1,38 @@
+package queue
+
+import "errors"
+
+type RPCReq struct {
+	method    string
+	replyChan chan interface{}
+}
+
+type RPCResponse string
+
+type Status struct {
+	queueChan chan RPCReq
+}
+
+type RPCArgs struct{}
+
+func (s *Status) Downloads(_ RPCArgs, reply *RPCResponse) error {
+	replyChan := make(chan interface{})
+	req := RPCReq{
+		method:    "download_status",
+		replyChan: replyChan,
+	}
+
+	s.queueChan <- req
+	qReply := <-replyChan
+
+	switch qReply.(type) {
+	case string:
+		*reply = RPCResponse(qReply.(string))
+		break
+	default:
+		return errors.New("error: unexpected return value")
+		break
+	}
+
+	return nil
+}


### PR DESCRIPTION
The command `hoarder -config <config_file> -getStatus` will now output the progress of all the current downloads in the format below. An RPC socket file was also added to the config spec.

```
Totally.Legit.Download.x264-KILLERS   |===============>              |  (50%)
ubuntu.13.37.iso                      |===>                          |  ( 7%)
Errored.Download.mkv                  |                              |  (error: could not stat file)
```
